### PR TITLE
Update classes of closest('.fl_wrap') instead of parent()

### DIFF
--- a/src/jquery.FlowupLabels.js
+++ b/src/jquery.FlowupLabels.js
@@ -15,18 +15,18 @@
 			var $scope  = $(this);
     
 			$scope.on('focus.flowupLabelsEvt', '.fl_input', function() {
-				$(this).parent().addClass(settings.class_focused);
+				$(this).closest('.fl_wrap').addClass(settings.class_focused);
 			})
 			.on('blur.flowupLabelsEvt', '.fl_input', function() {
 				var $this = $(this);
 				
 				if ($this.val().length) {
-					$this.parent()
+					$this.closest('.fl_wrap')
 						.addClass(settings.class_populated)
 						.removeClass(settings.class_focused);
 				} 
 				else {
-					$this.parent()
+					$this.closest('.fl_wrap')
 						.removeClass(settings.class_populated + ' ' + settings.class_focused);
 				}
 			});


### PR DESCRIPTION
This allows it to work even for cases where the input is a descendant, but not a direct child, of the .fl_wrap element. This happens, for instance, if you use the conventional bootstrap control-group hierarchy.
